### PR TITLE
Improve UI responsiveness with optimistic updates and instant navigation

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -200,19 +200,19 @@ export function App() {
           ? { repoId: selectedRepoId!, prompt, attachments }
           : { sessionId: selectedSessionId!, prompt, attachments }
       ),
-    onSuccess: async (data, variables) => {
+    onSuccess: (data, variables) => {
       setOptimisticMessage((current) =>
         current && current.sessionId === variables.clientSessionId
           ? { ...current, sessionId: data.run.sessionId }
           : current
       );
-      await queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.session(data.run.sessionId) });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.messages(data.run.sessionId) });
-      startTransition(() => {
-        setSelectedSessionId(data.run.sessionId);
-        setMobilePane("chat");
-      });
+      setSelectedSessionId(data.run.sessionId);
+      setMobilePane("chat");
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["sessions"] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.session(data.run.sessionId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.messages(data.run.sessionId) })
+      ]);
     },
     onError: () => {
       setOptimisticMessage((current) => {
@@ -286,18 +286,14 @@ export function App() {
   }, [messages, optimisticMessageForSession]);
 
   const selectRepo = (repoId: string | null) => {
-    startTransition(() => {
-      setSelectedRepoId(repoId);
-      setSelectedSessionId(null);
-      setMobilePane("sidebar");
-    });
+    setSelectedRepoId(repoId);
+    setSelectedSessionId(null);
+    setMobilePane("sidebar");
   };
 
   const selectSession = (sessionId: string) => {
-    startTransition(() => {
-      setSelectedSessionId(sessionId);
-      setMobilePane("chat");
-    });
+    setSelectedSessionId(sessionId);
+    setMobilePane("chat");
   };
 
   const startSidebarResize = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -347,15 +343,25 @@ export function App() {
             onFilterChange={setFilter}
             onSelectRepo={selectRepo}
             onSelectSession={selectSession}
+            onHoverSession={(sessionId: string) => {
+              void queryClient.prefetchQuery({
+                queryKey: queryKeys.session(sessionId),
+                queryFn: () => api.session(sessionId),
+                staleTime: 30_000
+              });
+              void queryClient.prefetchQuery({
+                queryKey: queryKeys.messages(sessionId),
+                queryFn: () => api.messages(sessionId),
+                staleTime: 30_000
+              });
+            }}
             isCreatingSession={false}
             onCreateSession={() => {
               if (!selectedRepoId) {
                 return;
               }
-              startTransition(() => {
-                setSelectedSessionId(`draft:${selectedRepoId}:${Date.now()}`);
-                setMobilePane("chat");
-              });
+              setSelectedSessionId(`draft:${selectedRepoId}:${Date.now()}`);
+              setMobilePane("chat");
             }}
           />
         </aside>
@@ -375,6 +381,7 @@ export function App() {
         <section className="workspace-shell__chat" data-mobile-visible={mobilePane === "chat"}>
           <ChatPane
             detail={detail}
+            isLoadingDetail={!isDraftSession && Boolean(selectedSessionId) && sessionDetailQuery.isLoading}
             messages={messages}
             streamingText={streamingText}
             liveActivities={liveActivities}
@@ -389,6 +396,16 @@ export function App() {
                 return;
               }
 
+              // Show optimistic message immediately — before any async work.
+              setOptimisticMessage((current) => {
+                revokeOptimisticAttachments(current);
+                return {
+                  sessionId: selectedSessionId,
+                  prompt,
+                  attachments: createOptimisticAttachments(files)
+                };
+              });
+
               const attachments = await Promise.all(
                 files.map(async (file) => {
                   const dataUrl = await readFileAsDataUrl(file);
@@ -400,15 +417,6 @@ export function App() {
                   } satisfies ImageAttachmentInput;
                 })
               );
-
-              setOptimisticMessage((current) => {
-                revokeOptimisticAttachments(current);
-                return {
-                  sessionId: selectedSessionId,
-                  prompt,
-                  attachments: createOptimisticAttachments(files)
-                };
-              });
 
               await runMutation.mutateAsync({
                 prompt,

--- a/apps/web/src/features/chat/ChatPane.tsx
+++ b/apps/web/src/features/chat/ChatPane.tsx
@@ -24,6 +24,7 @@ type ComposerImage = {
 
 type Props = {
   detail: SessionDetail | null | undefined;
+  isLoadingDetail: boolean;
   messages: Message[];
   streamingText: string;
   liveActivities: LiveActivity[];
@@ -292,8 +293,29 @@ const ConversationTimeline = memo(function ConversationTimeline({
   );
 });
 
+function ChatSkeletonContent() {
+  return (
+    <>
+      <div className="chat-head">
+        <div>
+          <div className="skeleton skeleton--title" />
+          <div className="skeleton skeleton--subtitle" />
+        </div>
+      </div>
+      <div className="timeline-wrap">
+        <div className="timeline">
+          <div className="skeleton skeleton--message skeleton--message-wide" />
+          <div className="skeleton skeleton--message" />
+          <div className="skeleton skeleton--message skeleton--message-wide" />
+        </div>
+      </div>
+    </>
+  );
+}
+
 export function ChatPane({
   detail,
+  isLoadingDetail,
   messages,
   streamingText,
   liveActivities,
@@ -405,22 +427,23 @@ export function ChatPane({
     return () => window.cancelAnimationFrame(frame);
   }, [messages, streamingText]);
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     const prompt = composerRef.current?.value.trim() ?? "";
     if (!prompt && selectedImages.length === 0) {
       return;
     }
 
-    await onSubmit({
-      prompt,
-      files: selectedImages.map((image) => image.file)
-    });
+    const files = selectedImages.map((image) => image.file);
 
+    // Clear composer immediately for snappy feedback — the optimistic message
+    // already reflects the user's input in the timeline.
     if (composerRef.current) {
       composerRef.current.value = "";
       composerRef.current.style.height = "auto";
     }
     clearSelectedImages();
+
+    void onSubmit({ prompt, files });
   };
 
   const autoResize = () => {
@@ -610,6 +633,8 @@ export function ChatPane({
             </div>
           </div>
         </>
+      ) : isLoadingDetail ? (
+        <ChatSkeletonContent />
       ) : (
         <div className="empty-state empty-state--chat">
           <strong>Select a thread</strong>

--- a/apps/web/src/features/sidebar/SidebarPane.tsx
+++ b/apps/web/src/features/sidebar/SidebarPane.tsx
@@ -17,6 +17,7 @@ type Props = {
   onFilterChange: (value: SessionFilter) => void;
   onSelectRepo: (repoId: string | null) => void;
   onSelectSession: (sessionId: string) => void;
+  onHoverSession: (sessionId: string) => void;
   onCreateSession: () => void;
 };
 
@@ -83,6 +84,7 @@ export function SidebarPane({
   onFilterChange,
   onSelectRepo,
   onSelectSession,
+  onHoverSession,
   onCreateSession
 }: Props) {
   const collapsedRepos = useUiStore((state) => state.collapsedRepos);
@@ -218,6 +220,7 @@ export function SidebarPane({
                       session={session}
                       isActive={selectedSessionId === session.id}
                       onSelect={onSelectSession}
+                      onHover={onHoverSession}
                       showRepo={false}
                     />
                   ))}
@@ -236,6 +239,7 @@ export function SidebarPane({
                 session={session}
                 isActive={selectedSessionId === session.id}
                 onSelect={onSelectSession}
+                onHover={onHoverSession}
                 showRepo={false}
               />
             ))}
@@ -250,17 +254,20 @@ function SessionRow({
   session,
   isActive,
   onSelect,
+  onHover,
   showRepo
 }: {
   session: SessionSummary;
   isActive: boolean;
   onSelect: (id: string) => void;
+  onHover: (id: string) => void;
   showRepo: boolean;
 }) {
   return (
     <button
       className={`session-row session-row--sidebar ${isActive ? "is-active" : ""}`}
       onClick={() => onSelect(session.id)}
+      onMouseEnter={() => onHover(session.id)}
       type="button"
     >
       <div className="session-row__head">

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1547,3 +1547,38 @@ button {
     grid-column: 1;
   }
 }
+
+/* ───────────────────── Skeleton placeholders ───────────────────── */
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.12; }
+  50% { opacity: 0.22; }
+}
+
+.skeleton {
+  background: var(--color-text);
+  border-radius: 4px;
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.skeleton--title {
+  width: 40%;
+  height: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton--subtitle {
+  width: 55%;
+  height: 0.75rem;
+}
+
+.skeleton--message {
+  width: 60%;
+  height: 3.5rem;
+  margin-bottom: 0.75rem;
+  border-radius: 8px;
+}
+
+.skeleton--message-wide {
+  width: 80%;
+}

--- a/docs/ui-responsiveness-principles.md
+++ b/docs/ui-responsiveness-principles.md
@@ -1,0 +1,89 @@
+# UI Responsiveness Principles
+
+This document defines the core principles for keeping the Codex Remote UI
+feeling fast and responsive. Every user-initiated action should produce
+**immediate visual feedback** — even before the server responds.
+
+---
+
+## 1. Optimistic Navigation
+
+**Principle**: User clicks on navigation elements (session rows, "New session"
+button) must update the URL / active view **synchronously** in the same event
+handler tick. Never gate a navigation behind a network request or
+`startTransition`.
+
+**Pattern**:
+- Set `selectedSessionId` and `mobilePane` directly via Zustand — no
+  `startTransition` wrapper for urgent user-initiated navigations.
+- Show a skeleton / placeholder for the target pane while data loads.
+
+## 2. Skeleton-First Loading
+
+**Principle**: When data is not yet available for a view the user navigated to,
+render a lightweight **skeleton placeholder** that mirrors the final layout.
+Never show a blank screen or an empty-state message while a query is in flight.
+
+**Pattern**:
+- ChatPane renders a skeleton header + skeleton timeline rows when
+  `sessionDetailQuery` is loading but `selectedSessionId` is set.
+- Skeletons use CSS `pulse` animation for a polished feel.
+
+## 3. Optimistic Input Reflection
+
+**Principle**: After the user submits a form or message, **immediately** reflect
+the input in the UI. Clear the composer, show the user's message in the
+timeline, and display a "thinking" indicator — all before the API call resolves.
+
+**Pattern**:
+- Clear the composer textarea and attached images **before** `await onSubmit()`.
+- Set the optimistic user message **before** starting the file-to-dataURL
+  conversion and API call.
+- Use blob URLs for instant image previews; convert to data URLs in the
+  background for the actual request.
+
+## 4. Fire-and-Forget Mutations
+
+**Principle**: After a mutation succeeds, **do not** block the UI on cache
+invalidation. Invalidate queries in parallel and without awaiting the result
+when the optimistic state is already correct.
+
+**Pattern**:
+- Use `Promise.all` for independent `queryClient.invalidateQueries` calls.
+- Use `void` (fire-and-forget) when the UI already reflects the correct state
+  via optimistic data and the invalidation is only for eventual consistency.
+
+## 5. Prefetch on Intent
+
+**Principle**: Anticipate user intent and **prefetch** data before the user
+commits to an action. Hovering a session row is a strong signal that the user
+is about to click it.
+
+**Pattern**:
+- `queryClient.prefetchQuery` for session detail and messages when the user
+  hovers (`onMouseEnter`) a session row in the sidebar.
+- Use a short `staleTime` (e.g., 30 seconds) so prefetched data is reused on
+  click without an extra request.
+
+## 6. Non-Blocking Transitions
+
+**Principle**: Reserve `startTransition` for **low-priority** derived state
+updates (e.g., filtering a large list via `useDeferredValue`). Never use it
+for direct user navigation actions — those must be synchronous.
+
+**Pattern**:
+- `selectSession`, `onCreateSession`: update Zustand state directly.
+- `setSearch` with `useDeferredValue`: appropriate use of transition for
+  debounced filtering.
+
+---
+
+## Checklist for New Features
+
+When adding a new interactive feature, verify:
+
+- [ ] Does the user see feedback within **one frame** (~16 ms) of their action?
+- [ ] Is there a skeleton/placeholder for any async data the view depends on?
+- [ ] Are form inputs cleared optimistically before the API call?
+- [ ] Are cache invalidations parallelized and non-blocking where possible?
+- [ ] Is data prefetched on hover for likely next navigations?


### PR DESCRIPTION
## Summary

UIの「もっさり感」を解消するため、以下の3つの操作を高速化しました：

- **New sessionクリック**: `startTransition`を除去し、Zustand直接更新で即座にチャットペインに遷移
- **既存セッションクリック**: ホバー時にprefetchでデータ先読み + データ取得中はスケルトン表示
- **初回メッセージ送信**: composerを即クリア、楽観メッセージをファイル読み込み前に表示、query invalidationを並列化・fire-and-forget化

## 大方針

`docs/ui-responsiveness-principles.md` にアプリ全体に適用できる6原則を定義しました：

1. Optimistic Navigation — ナビゲーションは同期的に即反映
2. Skeleton-First Loading — データ取得中はスケルトン表示
3. Optimistic Input Reflection — 入力は即座にUI反映
4. Fire-and-Forget Mutations — キャッシュ更新はUIをブロックしない
5. Prefetch on Intent — ホバー時にデータを先読み
6. Non-Blocking Transitions — startTransitionはフィルタリング等の低優先度のみ

## レビューで確認してほしいポイント

- 大方針ドキュメントの6原則に過不足はないか？このアプリのアーキテクチャに合っているか？
- `startTransition`の全面除去は適切か？React 19のconcurrent機能を活かすべきケースが残っていないか？
- `onSuccess`のquery invalidationをfire-and-forget(`void Promise.all`)にしたが、データ不整合のリスクはないか？
- スケルトンUIのデザイン・実装は十分か？
- prefetchの`staleTime: 30_000`は適切か？
- composerの即クリア後にAPIエラーが発生した場合のユーザー体験は問題ないか？

## Test plan

- [ ] New sessionボタンクリック → 即座にチャットペインに遷移すること
- [ ] サイドバーの既存セッションをホバー → Network tabでprefetchリクエストが飛ぶこと
- [ ] 既存セッションクリック → スケルトン表示後にデータが表示されること
- [ ] メッセージ送信 → composerが即クリアされ、楽観メッセージが表示されること
- [ ] 画像付きメッセージ送信 → blob URLプレビューが即表示されること
- [ ] API エラー時 → 楽観メッセージがクリアされること

https://claude.ai/code/session_01JkZA12bA2GqigLLm1MdW8K