### PR TITLE
Add persisted session unread state

### DIFF
--- a/.changeset/session-unread-state.md
+++ b/.changeset/session-unread-state.md
@@ -1,0 +1,5 @@
+---
+"rmtcdx": minor
+---
+
+Add persisted session unread state for live completions and errors, surface unread metadata in session list/detail responses, and only clear unread once the selected thread is actually visible and loaded.

--- a/apps/bridge/src/app.ts
+++ b/apps/bridge/src/app.ts
@@ -33,6 +33,7 @@ import { PushNotificationService } from "./notifications/push-notification-servi
 import { CodexDebugLog } from "./observability/codex-debug-log";
 import { RealtimeGateway } from "./realtime/realtime-gateway";
 import { RunService } from "./runs/run-service";
+import { SessionUnreadService } from "./sessions/session-unread-service";
 import { ImageUploadService } from "./uploads/image-upload-service";
 
 const filterSchema = z.enum(["all", "running", "unread", "completed", "interrupted", "error", "archived"]).optional();
@@ -173,9 +174,17 @@ export async function buildApp(overrides: BuildAppOverrides = {}) {
   const repoConfig = overrides.repoConfig ?? readRepoConfigOptional(config.reposFile);
   const catalog = new LiveCatalogService(codex, repoConfig, uploads);
   const pushNotifications = new PushNotificationService(config.stateFile, config, app.log);
+  const unread = new SessionUnreadService(`${config.dataDir}/session-read-state.json`);
   const realtime = new RealtimeGateway((event: ClientWsEvent) => {
     if (event.type === "ping") {
       realtime.broadcastPong();
+      return;
+    }
+
+    if (event.type === "session.read") {
+      void markSessionRead(event.sessionId).catch((error) => {
+        app.log.warn({ err: error, sessionId: event.sessionId }, "Unable to mark session as read from websocket event");
+      });
     }
   });
   const runs = new RunService(
@@ -185,6 +194,7 @@ export async function buildApp(overrides: BuildAppOverrides = {}) {
     codex,
     uploads,
     pushNotifications,
+    unread,
     app.log,
     codexDebugLog
   );
@@ -204,13 +214,28 @@ export async function buildApp(overrides: BuildAppOverrides = {}) {
       return session.pendingRequestCount === pendingRequestCount ? session : { ...session, pendingRequestCount };
     });
   };
-  const presentSession = (session: SessionSummary) => withPendingRequestCount(runs.presentSessionSummary(session));
-  const presentSessions = (sessions: SessionSummary[]) => withPendingRequestCounts(runs.presentSessionSummaries(sessions));
+  const presentSession = (session: SessionSummary) =>
+    withPendingRequestCount(unread.presentSessionSummary(runs.presentSessionSummary(session)));
+  const presentSessions = (sessions: SessionSummary[]) =>
+    withPendingRequestCounts(unread.presentSessionSummaries(runs.presentSessionSummaries(sessions)));
   const presentDetail = (detail: SessionDetail) => {
-    const presented = runs.presentSessionDetail(detail);
+    const presented = unread.presentSessionDetail(runs.presentSessionDetail(detail));
     const session = withPendingRequestCount(presented.session);
     return session === presented.session ? presented : { ...presented, session };
   };
+
+  async function markSessionRead(sessionId: string) {
+    const detail = await catalog.getSessionDetail(sessionId);
+    const changed = unread.markRead(sessionId);
+    if (!changed) {
+      return false;
+    }
+
+    const presented = presentDetail(detail);
+    realtime.broadcastSession(presented.session);
+    realtime.broadcastSessionDetail(presented);
+    return true;
+  }
 
   await app.register(cors, {
     origin: true,
@@ -433,8 +458,15 @@ export async function buildApp(overrides: BuildAppOverrides = {}) {
     }
   });
 
-  app.post("/api/sessions/:sessionId/read", async () => {
-    return { ok: true };
+  app.post("/api/sessions/:sessionId/read", async (request, reply) => {
+    const params = z.object({ sessionId: z.string().min(1) }).parse(request.params);
+
+    try {
+      await markSessionRead(params.sessionId);
+      return { ok: true };
+    } catch (error) {
+      return reply.code(400).send({ message: error instanceof Error ? error.message : "Unable to mark session as read" });
+    }
   });
 
   app.patch("/api/sessions/:sessionId", async (request, reply) => {

--- a/apps/bridge/src/runs/run-service.ts
+++ b/apps/bridge/src/runs/run-service.ts
@@ -17,6 +17,7 @@ import type { CodexBackend, CodexBridgeEvent } from "../codex/types";
 import { LiveCatalogService } from "../catalog/live-catalog-service";
 import { PushNotificationService } from "../notifications/push-notification-service";
 import { RealtimeGateway } from "../realtime/realtime-gateway";
+import { SessionUnreadService } from "../sessions/session-unread-service";
 import { ImageUploadService } from "../uploads/image-upload-service";
 import type { CodexDebugLog } from "../observability/codex-debug-log";
 import { resolveEffectiveCodexRunSettings, SessionRunSettingsStore } from "./session-run-settings-store";
@@ -59,6 +60,7 @@ export class RunService {
     private readonly codex: CodexBackend,
     private readonly uploads: ImageUploadService,
     private readonly pushNotifications: PushNotificationService,
+    private readonly sessionUnread: SessionUnreadService,
     private readonly logger: FastifyBaseLogger,
     private readonly debugLog?: CodexDebugLog,
     private readonly sessionRunSettings = new SessionRunSettingsStore(`${config.dataDir}/run-settings.json`)
@@ -375,6 +377,14 @@ export class RunService {
         text: event.text,
         createdAt: nowIso()
       };
+      if (event.countsUnread) {
+        this.sessionUnread.stageCompletion({
+          sessionId: event.sessionId,
+          runId: event.runId,
+          turnId: event.turnId,
+          createdAt: message.createdAt
+        });
+      }
       this.realtime.broadcastMessageFinal(event.sessionId, event.runId, message as Message & { role: "assistant" });
       return;
     }
@@ -450,6 +460,14 @@ export class RunService {
       errorMessage: event.type === "run.error" ? event.message : undefined
     };
     const shouldNotifyTerminalTransition = isRunInProgress(current.status) && isTerminalRunStatus(next.status);
+
+    if (event.type === "run.completed") {
+      this.sessionUnread.recordCompletion(event.sessionId, event.runId, event.turnId);
+    } else if (event.type === "run.error") {
+      this.sessionUnread.recordError(event.sessionId, event.runId, event.turnId, finishedAt);
+    } else {
+      this.sessionUnread.clearPendingTurn(event.sessionId, event.turnId);
+    }
 
     this.runsById.set(event.runId, next);
     this.activeRunBySession.delete(event.sessionId);

--- a/apps/bridge/src/sessions/session-unread-service.ts
+++ b/apps/bridge/src/sessions/session-unread-service.ts
@@ -1,0 +1,325 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { SessionDetail, SessionSummary } from "@codex-remote/shared-types";
+import { nowIso } from "../utils/time";
+
+type UnreadKind = "completion" | "error";
+
+type StoredUnreadEntry = {
+  seq: number;
+  kind: UnreadKind;
+  turnId: string;
+  runId?: string;
+  createdAt: string;
+};
+
+type StoredSessionUnreadState = {
+  lastEventSeq: number;
+  lastReadEventSeq: number;
+  unread: StoredUnreadEntry[];
+  updatedAt: string;
+};
+
+type StoredUnreadStateFile = {
+  version: 1;
+  sessions: Record<string, StoredSessionUnreadState>;
+};
+
+type PendingCompletion = {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  createdAt: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isUnreadKind(value: unknown): value is UnreadKind {
+  return value === "completion" || value === "error";
+}
+
+function normalizeUnreadEntry(value: unknown): StoredUnreadEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const rawSeq = value.seq;
+  const kind = value.kind;
+  const turnId = value.turnId;
+  const runId = value.runId;
+  const createdAt = value.createdAt;
+  const seq = typeof rawSeq === "number" && Number.isInteger(rawSeq) ? rawSeq : null;
+
+  if (
+    seq === null
+    || seq < 1
+    || !isUnreadKind(kind)
+    || typeof turnId !== "string"
+    || !turnId
+    || typeof createdAt !== "string"
+    || !createdAt
+  ) {
+    return null;
+  }
+
+  return {
+    seq,
+    kind,
+    turnId,
+    runId: typeof runId === "string" && runId ? runId : undefined,
+    createdAt
+  };
+}
+
+function normalizeSessionState(value: unknown): StoredSessionUnreadState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const unreadRaw = Array.isArray(value.unread) ? value.unread : [];
+  const unread = unreadRaw
+    .map((entry) => normalizeUnreadEntry(entry))
+    .filter((entry): entry is StoredUnreadEntry => Boolean(entry))
+    .sort((left, right) => left.seq - right.seq);
+  const maxSeq = unread.at(-1)?.seq ?? 0;
+  const parsedLastEventSeq = Number.isInteger(value.lastEventSeq) && (value.lastEventSeq as number) >= 0
+    ? (value.lastEventSeq as number)
+    : 0;
+  const lastEventSeq = Math.max(parsedLastEventSeq, maxSeq);
+  const parsedLastReadEventSeq = Number.isInteger(value.lastReadEventSeq) && (value.lastReadEventSeq as number) >= 0
+    ? (value.lastReadEventSeq as number)
+    : 0;
+  const lastReadEventSeq = Math.min(parsedLastReadEventSeq, lastEventSeq);
+  const filteredUnread = unread.filter((entry) => entry.seq > lastReadEventSeq && entry.seq <= lastEventSeq);
+
+  return {
+    lastEventSeq,
+    lastReadEventSeq,
+    unread: filteredUnread,
+    updatedAt: typeof value.updatedAt === "string" && value.updatedAt ? value.updatedAt : nowIso()
+  };
+}
+
+function unreadEntryKey(entry: Pick<StoredUnreadEntry, "kind" | "turnId" | "runId">) {
+  return `${entry.kind}:${entry.turnId}:${entry.runId ?? ""}`;
+}
+
+function pendingTurnKey(sessionId: string, turnId: string) {
+  return `${sessionId}:${turnId}`;
+}
+
+export class SessionUnreadService {
+  private readonly stateBySession = new Map<string, StoredSessionUnreadState>();
+  private readonly pendingCompletionByTurn = new Map<string, PendingCompletion>();
+
+  constructor(private readonly filePath: string) {
+    for (const [sessionId, state] of Object.entries(this.readState().sessions)) {
+      this.stateBySession.set(sessionId, state);
+    }
+  }
+
+  presentSessionSummary(session: SessionSummary) {
+    const state = this.stateBySession.get(session.id);
+    const unreadCount = state?.unread.length ?? 0;
+    const lastEventSeq = state?.lastEventSeq ?? 0;
+    const lastReadEventSeq = state?.lastReadEventSeq ?? 0;
+    const hasUnreadCompletion = state?.unread.some((entry) => entry.kind === "completion") ?? false;
+    const hasUnreadError = state?.unread.some((entry) => entry.kind === "error") ?? false;
+
+    if (
+      session.unreadCount === unreadCount
+      && session.lastEventSeq === lastEventSeq
+      && session.lastReadEventSeq === lastReadEventSeq
+      && session.hasUnreadCompletion === hasUnreadCompletion
+      && session.hasUnreadError === hasUnreadError
+    ) {
+      return session;
+    }
+
+    return {
+      ...session,
+      unreadCount,
+      lastEventSeq,
+      lastReadEventSeq,
+      hasUnreadCompletion,
+      hasUnreadError
+    } satisfies SessionSummary;
+  }
+
+  presentSessionSummaries(sessions: SessionSummary[]) {
+    return sessions.map((session) => this.presentSessionSummary(session));
+  }
+
+  presentSessionDetail(detail: SessionDetail) {
+    const session = this.presentSessionSummary(detail.session);
+    if (session === detail.session) {
+      return detail;
+    }
+
+    return {
+      ...detail,
+      session
+    };
+  }
+
+  stageCompletion(params: { sessionId: string; runId: string; turnId: string; createdAt?: string }) {
+    if (!params.sessionId || !params.runId || !params.turnId) {
+      return;
+    }
+
+    const key = pendingTurnKey(params.sessionId, params.turnId);
+    if (this.pendingCompletionByTurn.has(key)) {
+      return;
+    }
+
+    this.pendingCompletionByTurn.set(key, {
+      sessionId: params.sessionId,
+      runId: params.runId,
+      turnId: params.turnId,
+      createdAt: params.createdAt ?? nowIso()
+    });
+  }
+
+  recordCompletion(sessionId: string, runId: string, turnId: string) {
+    const key = pendingTurnKey(sessionId, turnId);
+    const pending = this.pendingCompletionByTurn.get(key);
+    this.pendingCompletionByTurn.delete(key);
+
+    if (!pending || pending.runId !== runId) {
+      return false;
+    }
+
+    return this.appendUnread(sessionId, {
+      kind: "completion",
+      turnId,
+      runId,
+      createdAt: pending.createdAt
+    });
+  }
+
+  recordError(sessionId: string, runId: string, turnId: string, createdAt = nowIso()) {
+    this.pendingCompletionByTurn.delete(pendingTurnKey(sessionId, turnId));
+
+    return this.appendUnread(sessionId, {
+      kind: "error",
+      turnId,
+      runId,
+      createdAt
+    });
+  }
+
+  clearPendingTurn(sessionId: string, turnId: string) {
+    this.pendingCompletionByTurn.delete(pendingTurnKey(sessionId, turnId));
+  }
+
+  markRead(sessionId: string) {
+    const current = this.stateBySession.get(sessionId);
+    if (!current) {
+      return false;
+    }
+
+    if (current.unread.length === 0 && current.lastReadEventSeq === current.lastEventSeq) {
+      return false;
+    }
+
+    const next: StoredSessionUnreadState = {
+      ...current,
+      lastReadEventSeq: current.lastEventSeq,
+      unread: [],
+      updatedAt: nowIso()
+    };
+    this.stateBySession.set(sessionId, next);
+    this.persistState();
+    return true;
+  }
+
+  private appendUnread(
+    sessionId: string,
+    unread: Omit<StoredUnreadEntry, "seq">
+  ) {
+    const current = this.stateBySession.get(sessionId) ?? {
+      lastEventSeq: 0,
+      lastReadEventSeq: 0,
+      unread: [],
+      updatedAt: unread.createdAt
+    } satisfies StoredSessionUnreadState;
+
+    const nextKey = unreadEntryKey(unread);
+    if (current.unread.some((entry) => unreadEntryKey(entry) === nextKey)) {
+      return false;
+    }
+
+    const nextSeq = current.lastEventSeq + 1;
+    const next: StoredSessionUnreadState = {
+      lastEventSeq: nextSeq,
+      lastReadEventSeq: current.lastReadEventSeq,
+      unread: [
+        ...current.unread,
+        {
+          seq: nextSeq,
+          ...unread
+        }
+      ],
+      updatedAt: nowIso()
+    };
+
+    this.stateBySession.set(sessionId, next);
+    this.persistState();
+    return true;
+  }
+
+  private readState(): StoredUnreadStateFile {
+    if (!fs.existsSync(this.filePath)) {
+      return {
+        version: 1,
+        sessions: {}
+      };
+    }
+
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8")) as unknown;
+      if (!isRecord(parsed) || !isRecord(parsed.sessions)) {
+        return {
+          version: 1,
+          sessions: {}
+        };
+      }
+
+      const sessions: Record<string, StoredSessionUnreadState> = {};
+      for (const [sessionId, value] of Object.entries(parsed.sessions)) {
+        if (!sessionId) {
+          continue;
+        }
+        const normalized = normalizeSessionState(value);
+        if (normalized) {
+          sessions[sessionId] = normalized;
+        }
+      }
+
+      return {
+        version: 1,
+        sessions
+      };
+    } catch {
+      return {
+        version: 1,
+        sessions: {}
+      };
+    }
+  }
+
+  private persistState() {
+    const state: StoredUnreadStateFile = {
+      version: 1,
+      sessions: Object.fromEntries(this.stateBySession.entries())
+    };
+
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    const tmpPath = `${this.filePath}.tmp`;
+    fs.writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    fs.renameSync(tmpPath, this.filePath);
+  }
+}

--- a/apps/bridge/test/codex-compat/bridge-smoke.test.ts
+++ b/apps/bridge/test/codex-compat/bridge-smoke.test.ts
@@ -16,6 +16,7 @@ import { buildApp } from "../../src/app";
 import type {
   CodexAccountRateLimits,
   CodexBackend,
+  CodexBridgeEvent,
   CodexRuntimeState,
   CodexThread,
   EnsureThreadParams,
@@ -207,6 +208,190 @@ test("fixture backend smoke test covers sessions, messages, and pending request 
   }
 });
 
+test("bridge smoke test tracks unread from live completion events and clears it on read", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-bridge-unread-"));
+  const repoPath = path.join(rootDir, "repo");
+  const dataDir = path.join(rootDir, "data");
+  const uploadsDir = path.join(dataDir, "uploads");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(uploadsDir, { recursive: true });
+
+  const thread: CodexThread = {
+    id: "fixture_thread_unread",
+    preview: "Unread fixture",
+    createdAt: 1711756800,
+    updatedAt: 1711756860,
+    status: { type: "idle" },
+    cwd: repoPath,
+    path: null,
+    name: null,
+    modelProvider: "openai",
+    source: "appServer",
+    gitInfo: {
+      sha: "abc123",
+      branch: "main",
+      originUrl: "https://example.test/repo.git"
+    },
+    turns: [
+      {
+        id: "fixture_turn_unread_1",
+        status: "completed",
+        error: null,
+        items: [
+          {
+            type: "userMessage",
+            id: "fixture_user_unread_1",
+            content: [
+              {
+                type: "text",
+                text: "Unread fixture",
+                text_elements: []
+              }
+            ]
+          },
+          {
+            type: "agentMessage",
+            id: "fixture_assistant_unread_1",
+            text: "Already completed before app start.",
+            phase: "final"
+          }
+        ]
+      }
+    ]
+  };
+
+  const backend = new FixtureBridgeBackend([thread]);
+  const config: AppConfig = {
+    port: 0,
+    host: "127.0.0.1",
+    reposFile: path.join(rootDir, "repos.json"),
+    dataDir,
+    stateFile: path.join(dataDir, "state.json"),
+    runtimeFile: path.join(dataDir, "runtime.json"),
+    codexDebugLogFile: path.join(dataDir, "codex-app-server.jsonl"),
+    uploadsDir,
+    webDistDir: path.join(rootDir, "missing-web-dist"),
+    codexMode: "mock",
+    maxPromptLength: 12_000,
+    maxImageAttachments: 5,
+    maxImageAttachmentBytes: 10_485_760,
+    devSimulatorEnabled: true
+  };
+
+  const { app, realtime } = await buildApp({
+    config,
+    codex: backend,
+    repoConfig: [
+      {
+        id: "fixture_repo",
+        name: "Fixture Repo",
+        path: repoPath,
+        pinned: false
+      }
+    ]
+  });
+
+  const wsEvents = createWebSocketCollector();
+  try {
+    realtime.register(wsEvents.socket, backend.getState().mode);
+    await wsEvents.waitFor((event) => event.type === "hello");
+
+    const initialSessions = await app.inject({
+      method: "GET",
+      url: "/api/sessions"
+    });
+    assert.equal(initialSessions.statusCode, 200);
+    const initialPayload = initialSessions.json() as {
+      sessions: Array<{ id: string; unreadCount: number; hasUnreadCompletion: boolean }>;
+    };
+    assert.equal(initialPayload.sessions[0]?.id, "fixture_thread_unread");
+    assert.equal(initialPayload.sessions[0]?.unreadCount, 0);
+    assert.equal(initialPayload.sessions[0]?.hasUnreadCompletion, false);
+
+    const startRunResponse = await app.inject({
+      method: "POST",
+      url: "/api/runs",
+      payload: {
+        sessionId: "fixture_thread_unread",
+        prompt: "Generate a fresh unread completion"
+      }
+    });
+    assert.equal(startRunResponse.statusCode, 200);
+    const startRunPayload = startRunResponse.json() as {
+      run: { id: string; turnId?: string };
+    };
+
+    backend.emit("event", {
+      type: "message.final",
+      sessionId: "fixture_thread_unread",
+      runId: startRunPayload.run.id,
+      turnId: startRunPayload.run.turnId ?? "fixture_turn_unread_2",
+      text: "Fresh unread completion",
+      countsUnread: true
+    } satisfies CodexBridgeEvent);
+    backend.emit("event", {
+      type: "run.completed",
+      sessionId: "fixture_thread_unread",
+      runId: startRunPayload.run.id,
+      turnId: startRunPayload.run.turnId ?? "fixture_turn_unread_2"
+    } satisfies CodexBridgeEvent);
+    await flushAsyncWork();
+
+    const unreadSessions = await app.inject({
+      method: "GET",
+      url: "/api/sessions"
+    });
+    assert.equal(unreadSessions.statusCode, 200);
+    const unreadPayload = unreadSessions.json() as {
+      sessions: Array<{
+        id: string;
+        unreadCount: number;
+        lastEventSeq: number;
+        lastReadEventSeq: number;
+        hasUnreadCompletion: boolean;
+        hasUnreadError: boolean;
+      }>;
+    };
+    assert.equal(unreadPayload.sessions[0]?.id, "fixture_thread_unread");
+    assert.equal(unreadPayload.sessions[0]?.unreadCount, 1);
+    assert.equal(unreadPayload.sessions[0]?.lastEventSeq, 1);
+    assert.equal(unreadPayload.sessions[0]?.lastReadEventSeq, 0);
+    assert.equal(unreadPayload.sessions[0]?.hasUnreadCompletion, true);
+    assert.equal(unreadPayload.sessions[0]?.hasUnreadError, false);
+
+    const readResponse = await app.inject({
+      method: "POST",
+      url: "/api/sessions/fixture_thread_unread/read"
+    });
+    assert.equal(readResponse.statusCode, 200);
+
+    const sessionUpdated = await wsEvents.waitFor(
+      (event): event is Extract<ServerWsEvent, { type: "sessions.updated" }> =>
+        event.type === "sessions.updated" && event.session.id === "fixture_thread_unread"
+    );
+    assert.equal(sessionUpdated.session.unreadCount, 0);
+    assert.equal(sessionUpdated.session.lastEventSeq, 1);
+    assert.equal(sessionUpdated.session.lastReadEventSeq, 1);
+
+    const readSessions = await app.inject({
+      method: "GET",
+      url: "/api/sessions"
+    });
+    assert.equal(readSessions.statusCode, 200);
+    const readPayload = readSessions.json() as {
+      sessions: Array<{ id: string; unreadCount: number; lastEventSeq: number; lastReadEventSeq: number }>;
+    };
+    assert.equal(readPayload.sessions[0]?.id, "fixture_thread_unread");
+    assert.equal(readPayload.sessions[0]?.unreadCount, 0);
+    assert.equal(readPayload.sessions[0]?.lastEventSeq, 1);
+    assert.equal(readPayload.sessions[0]?.lastReadEventSeq, 1);
+  } finally {
+    wsEvents.socket.emit("close");
+    await app.close();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+});
+
 class FixtureBridgeBackend extends EventEmitter implements CodexBackend {
   private readonly threads = new Map<string, CodexThread>();
   private readonly pendingRequests = new Map<string, CodexPendingRequest>();
@@ -264,7 +449,10 @@ class FixtureBridgeBackend extends EventEmitter implements CodexBackend {
   }
 
   async startRun(_params: StartRunParams): Promise<StartRunResult> {
-    throw new Error("Not implemented in fixture backend");
+    return {
+      threadId: _params.sessionId ?? _params.threadId ?? [...this.threads.keys()][0] ?? "fixture_thread",
+      turnId: `fixture_turn_${randomUUID()}`
+    };
   }
 
   async interruptRun(_runId: string, _threadId: string, _turnId: string) {
@@ -387,4 +575,8 @@ function createWebSocketCollector() {
       });
     }
   };
+}
+
+async function flushAsyncWork() {
+  await new Promise((resolve) => setImmediate(resolve));
 }

--- a/apps/bridge/test/codex-compat/run-service.test.ts
+++ b/apps/bridge/test/codex-compat/run-service.test.ts
@@ -12,6 +12,7 @@ import type { AppConfig } from "../../src/config/env";
 import { RealtimeGateway } from "../../src/realtime/realtime-gateway";
 import { RunService } from "../../src/runs/run-service";
 import { SessionRunSettingsStore } from "../../src/runs/session-run-settings-store";
+import { SessionUnreadService } from "../../src/sessions/session-unread-service";
 
 const logger = {
   warn() {}
@@ -78,12 +79,68 @@ test("run service exposes the last effective run settings for the thread", async
   });
 });
 
+test("run service records completion unread only after a counted final assistant message completes the turn", async () => {
+  const harness = createHarness();
+  const run = await harness.service.start({
+    repoId: "repo-1",
+    prompt: "Ship it"
+  });
+
+  harness.backend.emitMessageFinal(run.id, run.turnId ?? "turn-1", true);
+  await flushAsyncWork();
+  harness.backend.emitTerminalEvent("run.completed", run.id, run.turnId ?? "turn-1");
+  await flushAsyncWork();
+
+  const presented = harness.unread.presentSessionDetail(harness.service.presentSessionDetail(harness.detail));
+  assert.equal(presented.session.unreadCount, 1);
+  assert.equal(presented.session.lastEventSeq, 1);
+  assert.equal(presented.session.hasUnreadCompletion, true);
+  assert.equal(presented.session.hasUnreadError, false);
+});
+
+test("run service ignores completion unread for commentary-only assistant output", async () => {
+  const harness = createHarness();
+  const run = await harness.service.start({
+    repoId: "repo-1",
+    prompt: "Talk me through it"
+  });
+
+  harness.backend.emitMessageFinal(run.id, run.turnId ?? "turn-1", false);
+  await flushAsyncWork();
+  harness.backend.emitTerminalEvent("run.completed", run.id, run.turnId ?? "turn-1");
+  await flushAsyncWork();
+
+  const presented = harness.unread.presentSessionDetail(harness.service.presentSessionDetail(harness.detail));
+  assert.equal(presented.session.unreadCount, 0);
+  assert.equal(presented.session.lastEventSeq, 0);
+});
+
+test("run service records error unread on failed runs", async () => {
+  const harness = createHarness();
+  const run = await harness.service.start({
+    repoId: "repo-1",
+    prompt: "Break it"
+  });
+
+  harness.backend.emitTerminalEvent("run.error", run.id, run.turnId ?? "turn-1");
+  await flushAsyncWork();
+
+  const presented = harness.unread.presentSessionDetail(harness.service.presentSessionDetail(harness.detail));
+  assert.equal(presented.session.unreadCount, 1);
+  assert.equal(presented.session.lastEventSeq, 1);
+  assert.equal(presented.session.hasUnreadCompletion, false);
+  assert.equal(presented.session.hasUnreadError, true);
+});
+
 function createHarness() {
   const backend = new FakeCodexBackend();
   const detail = createSessionDetail("Deploy preview");
   const notifications: Array<{ detail: SessionDetail; run: Run }> = [];
   const runSettingsStore = new SessionRunSettingsStore(
     path.join(os.tmpdir(), `rmtcdx-run-settings-${Date.now()}-${Math.random().toString(16).slice(2)}.json`)
+  );
+  const unread = new SessionUnreadService(
+    path.join(os.tmpdir(), `rmtcdx-session-unread-${Date.now()}-${Math.random().toString(16).slice(2)}.json`)
   );
 
   const service = new RunService(
@@ -114,6 +171,7 @@ function createHarness() {
         notifications.push({ detail: sessionDetail, run });
       }
     } as never,
+    unread,
     logger,
     undefined,
     runSettingsStore
@@ -123,6 +181,7 @@ function createHarness() {
     backend,
     detail,
     notifications,
+    unread,
     service
   };
 }
@@ -205,6 +264,19 @@ class FakeCodexBackend extends EventEmitter {
   }
 
   async interruptRun() {}
+
+  emitMessageFinal(runId: string, turnId: string, countsUnread: boolean) {
+    const event: CodexBridgeEvent = {
+      type: "message.final",
+      sessionId: "thread-1",
+      runId,
+      turnId,
+      text: countsUnread ? "Final answer" : "Thinking aloud",
+      countsUnread
+    };
+
+    this.emit("event", event);
+  }
 
   emitTerminalEvent(
     eventType: Extract<CodexBridgeEvent["type"], "run.completed" | "run.interrupted" | "run.error">,

--- a/apps/bridge/test/codex-compat/session-unread-service.test.ts
+++ b/apps/bridge/test/codex-compat/session-unread-service.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { SessionSummary } from "@codex-remote/shared-types";
+import { SessionUnreadService } from "../../src/sessions/session-unread-service";
+
+test("session unread service persists unread cursors across restarts", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "rmtcdx-session-unread-"));
+  const filePath = path.join(tempDir, "session-read-state.json");
+
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const service = new SessionUnreadService(filePath);
+  service.stageCompletion({
+    sessionId: "thread-1",
+    runId: "run-1",
+    turnId: "turn-1",
+    createdAt: "2026-03-31T12:00:00.000Z"
+  });
+  assert.equal(service.recordCompletion("thread-1", "run-1", "turn-1"), true);
+  assert.equal(service.recordError("thread-1", "run-2", "turn-2", "2026-03-31T12:01:00.000Z"), true);
+  assert.equal(service.markRead("thread-1"), true);
+  service.stageCompletion({
+    sessionId: "thread-1",
+    runId: "run-3",
+    turnId: "turn-3",
+    createdAt: "2026-03-31T12:02:00.000Z"
+  });
+  assert.equal(service.recordCompletion("thread-1", "run-3", "turn-3"), true);
+
+  const restored = new SessionUnreadService(filePath);
+  const presented = restored.presentSessionSummary(createSessionSummary());
+
+  assert.equal(presented.unreadCount, 1);
+  assert.equal(presented.lastEventSeq, 3);
+  assert.equal(presented.lastReadEventSeq, 2);
+  assert.equal(presented.hasUnreadCompletion, true);
+  assert.equal(presented.hasUnreadError, false);
+});
+
+test("session unread service does not backfill completion unread without a staged live final message", () => {
+  const service = new SessionUnreadService(path.join(os.tmpdir(), `rmtcdx-session-unread-${Date.now()}.json`));
+
+  assert.equal(service.recordCompletion("thread-1", "run-1", "turn-1"), false);
+
+  const presented = service.presentSessionSummary(createSessionSummary());
+  assert.equal(presented.unreadCount, 0);
+  assert.equal(presented.lastEventSeq, 0);
+  assert.equal(presented.hasUnreadCompletion, false);
+});
+
+function createSessionSummary(): SessionSummary {
+  const now = "2026-03-31T12:00:00.000Z";
+
+  return {
+    id: "thread-1",
+    repoId: "repo-1",
+    repoName: "Fixture Repo",
+    title: "Unread fixture",
+    summary: "Unread fixture",
+    status: "completed",
+    isArchived: false,
+    unreadCount: 0,
+    lastEventSeq: 0,
+    lastReadEventSeq: 0,
+    lastMessageAt: now,
+    pendingRequestCount: 0,
+    hasUnreadCompletion: false,
+    hasUnreadError: false,
+    createdAt: now,
+    updatedAt: now
+  };
+}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -214,6 +214,22 @@ function readIsMobileViewport() {
   return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
 }
 
+function readIsPageVisible() {
+  if (typeof document === "undefined") {
+    return true;
+  }
+
+  return document.visibilityState === "visible";
+}
+
+function readIsWindowFocused() {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  return window.document.hasFocus();
+}
+
 function buildSessionPath(sessionId: string) {
   return `/sessions/${encodeURIComponent(sessionId)}`;
 }
@@ -284,6 +300,8 @@ export function App() {
   });
   const [isResizingSidebar, setIsResizingSidebar] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(() => readIsMobileViewport());
+  const [isPageVisible, setIsPageVisible] = useState(() => readIsPageVisible());
+  const [isWindowFocused, setIsWindowFocused] = useState(() => readIsWindowFocused());
   const deferredSearch = useDeferredValue(search);
   const routeSessionId = useMemo(() => readSessionIdFromPathname(location.pathname), [location.pathname]);
 
@@ -405,6 +423,33 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      setIsPageVisible(document.visibilityState === "visible");
+    };
+    const handleFocus = () => {
+      setIsWindowFocused(true);
+    };
+    const handleBlur = () => {
+      setIsWindowFocused(false);
+    };
+
+    handleVisibilityChange();
+    setIsWindowFocused(window.document.hasFocus());
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  useEffect(() => {
     const firstSession = sessionsQuery.data?.sessions[0];
     if (isMobileViewport || routeSessionId || !firstSession) {
       return;
@@ -425,10 +470,37 @@ export function App() {
 
   useEffect(() => {
     const selected = sessionsQuery.data?.sessions.find((session) => session.id === selectedSessionId);
-    if (selectedSessionId && selected?.unreadCount) {
-      void api.markRead(selectedSessionId).catch(() => undefined);
+    if (
+      !selectedSessionId
+      || isDraftSession
+      || !selected?.unreadCount
+      || (!sessionDetailQuery.data || sessionDetailQuery.data.session.id !== selectedSessionId)
+      || !sessionDetailQuery.isSuccess
+      || !messagesQuery.isSuccess
+      || !isPageVisible
+      || !isWindowFocused
+      || (isMobileViewport && mobilePane !== "chat")
+    ) {
+      return;
     }
-  }, [selectedSessionId, sessionsQuery.data?.sessions]);
+
+    const timeoutId = window.setTimeout(() => {
+      void api.markRead(selectedSessionId).catch(() => undefined);
+    }, 750);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    isDraftSession,
+    isMobileViewport,
+    isPageVisible,
+    isWindowFocused,
+    messagesQuery.isSuccess,
+    mobilePane,
+    selectedSessionId,
+    sessionDetailQuery.data,
+    sessionDetailQuery.isSuccess,
+    sessionsQuery.data?.sessions
+  ]);
 
   useEffect(() => {
     window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth));

--- a/apps/web/src/app/view-state.test.ts
+++ b/apps/web/src/app/view-state.test.ts
@@ -131,3 +131,14 @@ test("sessionDetailSyncKey changes when a polled summary gets ahead of detail st
 
   assert.notEqual(sessionDetailSyncKey(summary), sessionDetailSyncKey(polledSummary));
 });
+
+test("sessionDetailSyncKey changes when unread state changes without a status transition", () => {
+  const unreadSummary: SessionSummary = {
+    ...summary,
+    unreadCount: 1,
+    lastEventSeq: 1,
+    hasUnreadCompletion: true
+  };
+
+  assert.notEqual(sessionDetailSyncKey(summary), sessionDetailSyncKey(unreadSummary));
+});

--- a/apps/web/src/app/view-state.ts
+++ b/apps/web/src/app/view-state.ts
@@ -140,12 +140,17 @@ export function sessionDetailSyncKey(session: SessionSummary | null | undefined)
     session.lastMessageAt,
     session.lastUserMessageAt ?? null,
     session.lastRunFinishedAt ?? null,
+    session.unreadCount,
+    session.lastEventSeq,
+    session.lastReadEventSeq,
     session.status,
     session.statusReasonCode ?? null,
     session.statusConfidence ?? null,
     session.latestTurnStatus ?? null,
     session.threadStatusType ?? null,
-    session.isArchived
+    session.isArchived,
+    session.hasUnreadCompletion,
+    session.hasUnreadError
   ]);
 }
 

--- a/docs/session-unread-state-design.md
+++ b/docs/session-unread-state-design.md
@@ -1,0 +1,251 @@
+# Session Unread State Design
+
+このドキュメントは、thread 一覧 / detail 同期の既存フローに合わせて、
+session unread state をどう生成・保存・配信するかを整理する。
+
+前提となる既存フローは
+[`docs/session-list-detail-sync-sequence.md`](./session-list-detail-sync-sequence.md)
+を参照する。
+
+## Goals
+
+- 過去 thread を初回表示しただけで unread にしない
+- thread の live completion / error だけを unread に昇格する
+- unread を session status と同じく `bridge` 側の overlay state として扱う
+- browser refresh / bridge restart 後も未読を維持する
+- list poll と detail fetch の既存整合フローに自然に乗る
+
+## Non-goals
+
+- `codex app-server` の thread snapshot から historical unread を推定すること
+- bridge 停止中に完了した thread を restart 後に unread として backfill すること
+- V1 で multi-tab / multi-device の active viewer presence を厳密に取ること
+
+## Constraints
+
+- current `thread/read` snapshot には read receipt / read cursor はない
+- live bridge event には `message.final.countsUnread` がある
+- session 一覧は 10 秒 poll、detail/messages は selected session のみ fetch される
+- `RunService` はすでに session status を local overlay として導出している
+
+## Design Summary
+
+- unread の source of truth は `bridge` の `SessionUnreadService`
+- unread の保存先は `DATA_DIR/session-read-state.json`
+- unread の生成契機は live terminal event のみ
+- unread の表示値は `catalog` の snapshot に対する present-time overlay として付与する
+- 既読化は `POST /api/sessions/:sessionId/read` で行う
+
+## Data Model
+
+保存モデルは session 単位の event cursor と unread queue を持つ。
+
+```ts
+type StoredUnreadState = {
+  version: 1;
+  sessions: Record<string, {
+    lastEventSeq: number;
+    lastReadEventSeq: number;
+    unread: Array<{
+      seq: number;
+      kind: "completion" | "error";
+      turnId: string;
+      runId?: string;
+      createdAt: string;
+    }>;
+    updatedAt: string;
+  }>;
+};
+```
+
+### Why This Shape
+
+- `lastEventSeq`
+  - session 内で bridge が live に観測した unread-capable terminal event の単調増加 cursor
+- `lastReadEventSeq`
+  - ユーザーが既読化した位置
+- `unread[]`
+  - 現在の unread badge / filter / icon を直接導出するための最小集合
+
+このモデルだと、`SessionSummary` の既存フィールド
+
+- `unreadCount`
+- `lastEventSeq`
+- `lastReadEventSeq`
+- `hasUnreadCompletion`
+- `hasUnreadError`
+
+を lossless に埋められる。
+
+## Event Rules
+
+### 1. `message.final`
+
+- `countsUnread = false`
+  - unread 候補にしない
+- `countsUnread = true`
+  - その turn を `completion pending` として一時保持する
+  - この時点では unread を増やさない
+
+理由:
+
+- commentary や途中の assistant output を unread として数えたくない
+- unread は terminal turn として確定した時点でのみ立てる
+
+### 2. `run.completed`
+
+- 同一 turn に `completion pending` があれば
+  - unread entry `kind = "completion"` を append
+- pending がなければ
+  - unread を増やさない
+
+理由:
+
+- live event を観測できなかった historical completion を unread にしないため
+
+### 3. `run.error`
+
+- `kind = "error"` unread を append
+- 同一 turn の pending completion は捨てる
+
+### 4. `run.interrupted`
+
+- V1 では unread を立てない
+- 同一 turn の pending completion は捨てる
+
+## Persistence Rules
+
+- unread state は event 処理時と mark-read 時に即時 persist する
+- persist は tmp file + rename の atomic write とする
+- state file 不在時は空 state で起動する
+- parse failure 時は warn 相当の fallback ではなく空 state で続行する
+
+## Presenter Integration
+
+既存の session state 導出は次の順で行う。
+
+1. `catalog`
+   - `thread/list` / `thread/read` snapshot から base `SessionSummary` / `SessionDetail` を作る
+2. `RunService`
+   - local active/latest run を使って status を overlay する
+3. `SessionUnreadService`
+   - persisted unread state を overlay する
+4. `app.ts`
+   - pending request count を overlay する
+
+つまり unread は status と同じく
+"snapshot そのもの" ではなく "bridge-owned projection" として扱う。
+
+## Read Trigger
+
+既読化は「selected になった瞬間」ではなく、以下を満たした時だけ行う。
+
+- real session である
+- current route の `selectedSessionId` と一致する
+- `sessionDetailQuery` が success
+- `messagesQuery` が success
+- page が visible
+- window が focused
+- mobile の場合は chat pane が前面にある
+- `unreadCount > 0`
+- 条件成立後に短い debounce を置く
+
+理由:
+
+- background tab のまま既読化しない
+- detail / messages 未取得の状態で既読化しない
+- mobile で sidebar 側にいるだけの状態を既読とみなさない
+
+## Detail Sync
+
+既存の `sessionDetailSyncKey()` は polled summary が detail より先に進んだ時に
+detail refetch を起こす。
+
+unread を list/detail 一貫で見せるため、sync key に以下を加える。
+
+- `unreadCount`
+- `lastEventSeq`
+- `lastReadEventSeq`
+- `hasUnreadCompletion`
+- `hasUnreadError`
+
+これにより、unread overlay だけが変わったケースでも detail 側が自然に追従する。
+
+## Lifecycle
+
+### Browser open with old completed threads
+
+- `GET /api/sessions`
+- `catalog` が completed session を返す
+- unread state に live-generated entry がなければ unread は 0
+- 過去 thread は unread にならない
+
+### New assistant completion while thread is not being read
+
+- `message.final(countsUnread=true)` を live で観測
+- `completion pending` を stage
+- `run.completed` を観測
+- unread entry を append
+- `sessionsQuery` / `sessionDetailQuery` が refetch される
+- list/detail に unread が表示される
+
+### User opens the thread and reads it
+
+- detail/messages load
+- page visible + focused
+- debounce 後に `POST /api/sessions/:id/read`
+- `lastReadEventSeq = lastEventSeq`
+- unread queue を空にする
+- `sessions.updated` / `session.updated` を broadcast
+
+## Sequences
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Codex as codex app-server
+    participant Run as RunService
+    participant Unread as SessionUnreadService
+    participant Store as session-read-state.json
+    participant REST as bridge REST
+    participant Browser
+
+    Codex-->>Run: message.final(countsUnread=true)
+    Run->>Unread: stage completion candidate
+    Codex-->>Run: run.completed
+    Run->>Unread: append completion unread
+    Unread->>Store: persist
+    Browser->>REST: GET /api/sessions
+    REST->>Unread: present SessionSummary[]
+    REST-->>Browser: unreadCount = 1
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Browser
+    participant REST as bridge REST
+    participant Unread as SessionUnreadService
+    participant Store as session-read-state.json
+    participant WS as bridge WebSocket
+
+    Browser->>REST: POST /api/sessions/:id/read
+    REST->>Unread: markRead(sessionId)
+    Unread->>Store: persist
+    REST->>WS: sessions.updated
+    REST->>WS: session.updated
+    WS-->>Browser: updated summary/detail
+```
+
+## Trade-offs
+
+- bridge 停止中に完了した thread は unread にしない
+  - これは欠点だが、historical completion を勝手に unread 化しないことを優先する
+- V1 では foreground viewer presence を共有しない
+  - 同一 session を別 tab で開いていると、片方が read API を叩くまで unread は残る
+
+## Future Extensions
+
+- WebSocket `session.read` を primary path に寄せる
+- active viewer presence を持ち、foreground viewer がいる session では unread 生成を抑制する
+- interruption unread の扱いを UX で再検討する


### PR DESCRIPTION
## Summary
- add a session unread design doc that fits the existing list/detail sync flow
- persist unread completion/error state in the bridge and overlay it onto session summary/detail responses
- tighten the web read trigger so unread is only cleared after the selected thread is actually visible and loaded

## Testing
- npm run typecheck -w rmtcdx
- npm run typecheck -w @codex-remote/web
- npm run lint -w rmtcdx
- npm run lint -w @codex-remote/web
- npm test -w rmtcdx
- npm test -w @codex-remote/web
- git push -u origin feat/session-unread-state